### PR TITLE
Fix for VueMultiselect

### DIFF
--- a/dev/schema.js
+++ b/dev/schema.js
@@ -120,8 +120,7 @@ module.exports = {
 			],
 			onChanged(model, newVal, oldVal, field) {
 				console.log(`Model's name changed from ${oldVal} to ${newVal}. Model:`, model);
-			},
-			min: 2,
+			},			
 			max: 4,
 			placeholder: "placeholder",
 			validator: validators.array

--- a/src/fields/fieldVueMultiSelect.vue
+++ b/src/fields/fieldVueMultiSelect.vue
@@ -7,6 +7,7 @@
 		:key="schema.selectOptions.key || null",
 		:label="schema.selectOptions.label || null",
 		:searchable="schema.selectOptions.searchable",
+		:local-search="schema.selectOptions.localSearch",
 		:clear-on-select="schema.selectOptions.clearOnSelect",
 		:hide-selected="schema.selectOptions.hideSelected",
 		:placeholder="schema.placeholder",
@@ -24,8 +25,7 @@
 		@remove="onRemove",
 		@search-change="onSearchChange",
 		@open="onOpen",
-		@close="onClose",
-		:show-pointer="schema.selectOptions.showPointer",
+		@close="onClose",		
 		:select-label="schema.selectOptions.selectLabel",
 		:selected-label="schema.selectOptions.selectedLabel",
 		:deselect-label="schema.selectOptions.deselectLabel",
@@ -34,6 +34,9 @@
 		:limit-text="schema.selectOptions.limitText",
 		:loading="schema.selectOptions.loading",
 		:disabled="disabled",
+		:option-partial="schema.selectOptions.optionPartial",
+		:show-pointer="schema.selectOptions.showPointer",
+		:option-height="schema.selectOptions.optionHeight"
 	)
 </template>
 <script>


### PR DESCRIPTION
While doing the documentation, I noticed some missing options for VueMultiselect.
I also removed `min` from dev schema because it was not used. You can only prevent empty (with `allowEmpty: false`), but not specify a minimum number of option to select, only a maximum.