### PR TITLE
fix: fragment instance warning

### DIFF
--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -1,4 +1,5 @@
 <template lang="jade">
+div
 	fieldset.vue-form-generator(v-if="schema != null")
 		.form-group(v-for="field in fields", v-if="fieldVisible(field)", :class="getFieldRowClasses(field)")
 			label {{ field.label }}


### PR DESCRIPTION
Fix for #45 
It seem like a `fieldset` don't count as a root element for Vue. I added a `div` and it fix the warning.