### PR TITLE
Allow form fields required state to be controlled with a function

### DIFF
--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -108,7 +108,7 @@ div
 					disabled: this.fieldDisabled(field), 
 					readonly: field.readonly, 
 					featured: field.featured, 
-					required: field.required
+					required: this.fieldRequired(field)
 				};
 
 				if (isArray(field.styleClasses)) {
@@ -137,6 +137,17 @@ div
 					return false;
 
 				return field.disabled;
+			},
+
+			// Get required prop of field
+			fieldRequired(field) {
+				if (isFunction(field.required))
+					return field.required(this.model);
+
+				if (isNil(field.required))
+					return false;
+
+				return field.required;
 			},
 
 			// Get visible prop of field

--- a/test/unit/specs/VueFormGenerator.spec.js
+++ b/test/unit/specs/VueFormGenerator.spec.js
@@ -306,6 +306,41 @@ describe("VueFormGenerator.vue", () => {
 
 	});
 
+	describe("check fieldRequired with function", () => {
+		let schema = {
+			fields: [
+				{	
+					type: "text",		
+					label: "Name", 
+					model: "name", 
+					required(model) { return model.status; }	
+				}
+			]
+		};
+		
+		let model = {
+			name: "John Doe",
+			status: true
+		};
+
+		before( () => {
+			createFormGenerator(schema, model);
+		});
+
+		it("should be required", () => {
+			expect(el.querySelector(".form-group").classList.contains("required")).to.be.true;
+		});	
+
+		it("should be optional", (done) => {
+			model.status = false;
+			vm.$nextTick(() => {
+				expect(el.querySelector(".form-group").classList.contains("required")).to.be.false;
+				done();
+			});
+		});	
+
+	});
+
 	describe("check fieldVisible with function", () => {
 		let schema = {
 			fields: [


### PR DESCRIPTION
This PR allows you to use a callback function with model to control the `required` state of a form field.

Example to make a field only required, if another field is empty:

```js
{
    type: "text",
    label: "Phone mobile",
    model: "phone_mobile",
    required: function(model) {
    	return (model.phone_home === null);
    }
}
```