### PR TITLE
Improve validations & bindings

### DIFF
--- a/dev/full/app.vue
+++ b/dev/full/app.vue
@@ -15,7 +15,7 @@
       <div class="errors text-center">
         <div v-for="(item, index) in validationErrors" track-by="index" class="alert alert-danger">{{ item.field.label}}: <strong>{{ item.error }}</strong></div>
       </div>
-      <vue-form-generator :schema="schema" :model="model" :options="formOptions" :multiple="selected.length > 1" ref="form" :is-new-model="isNewModel" @model-updated="modelUpdated"></vue-form-generator>
+      <vue-form-generator :schema="schema" :model="model" :options="formOptions" :multiple="selected.length > 1" ref="form" :is-new-model="isNewModel" @model-updated="modelUpdated" @validated="onValidated"></vue-form-generator>
     </div>
     <div class="col-md-6">
       <pre v-if="model" v-html="prettyModel"></pre>
@@ -113,7 +113,11 @@
 			clearSelection() {
 				this.selected.splice(0);
 				this.generateModel();
-			},			
+			},	
+
+			onValidated(res, errors) {
+				console.log("VFG validated:", res, errors);
+			},
 
 			generateModel() {
 				if (this.selected.length == 1) {
@@ -185,7 +189,7 @@
 			},
 
 			validate()	{
-				console.log("validate", this.$refs.form, this.$refs.form.validate());
+				//console.log("validate", this.$refs.form, this.$refs.form.validate());
 				return this.$refs.form.validate();
 			},
 

--- a/src/fields/abstractField.js
+++ b/src/fields/abstractField.js
@@ -7,6 +7,12 @@ export default {
 		"disabled"
 	],
 
+	data() {
+		return {
+			errors: []
+		};
+	},
+
 	computed: {
 		value: {
 			cache: false,
@@ -44,7 +50,7 @@ export default {
 					this.$emit("model-updated", newValue, this.schema.model);
 
 					if (isFunction(this.schema.onChanged)) {
-						this.schema.onChanged(this.model, newValue, oldValue, this.schema);
+						this.schema.onChanged.call(this, this.model, newValue, oldValue, this.schema);
 					}
 
 					if (this.$parent.options && this.$parent.options.validateAfterChanged === true){
@@ -56,7 +62,7 @@ export default {
 	},
 
 	methods: {
-		validate() {
+		validate(calledParent) {
 			this.clearValidationErrors();
 
 			if (this.schema.validator && this.schema.readonly !== true && this.disabled !== true) {
@@ -74,26 +80,27 @@ export default {
 					let err = validator(this.value, this.schema, this.model);
 					if (err) {
 						if (isArray(err))
-							Array.prototype.push.apply(this.schema.errors, err);
+							Array.prototype.push.apply(this.errors, err);
 						else if (isString(err))
-							this.schema.errors.push(err);
+							this.errors.push(err);
 					}
 				});
 
 			}
 
 			if (isFunction(this.schema.onValidated)) {
-				this.schema.onValidated(this.model, this.schema.errors, this.schema);
+				this.schema.onValidated.call(this, this.model, this.errors, this.schema);
 			}
 
-			return this.schema.errors;
+			let isValid = this.errors.length == 0;
+			if (!calledParent)
+				this.$emit("validated", isValid, this.errors, this);
+
+			return this.errors;
 		},
 
 		clearValidationErrors() {
-			if (isUndefined(this.schema.errors))
-				this.$root.$set(this.schema, "errors", []); // Be reactive
-			else
-				this.schema.errors.splice(0); // Clear
+			this.errors.splice(0);
 		},
 
 		setModelValueByPath(path, value) {

--- a/src/fields/abstractField.js
+++ b/src/fields/abstractField.js
@@ -1,4 +1,4 @@
-import { get as objGet, each, isFunction, isString, isArray, isUndefined } from "lodash";
+import { get as objGet, each, isFunction, isString, isArray } from "lodash";
 
 export default {
 	props: [

--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -223,7 +223,7 @@ div
 				});
 
 				let isValid = this.errors.length == 0;
-				this.$emit('on-validated', isValid, this.errors);
+				this.$emit("validated", isValid, this.errors);
 				return isValid;
 			},
 

--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -13,8 +13,8 @@ div
 					.buttons(v-if='buttonVisibility(field)')
 						button(v-for='btn in field.buttons', @click='btn.onclick(model, field)', :class='btn.classes') {{ btn.label }}
 				.hint(v-if='field.hint') {{ field.hint }}
-				.errors(v-if='errorsVisibility(field)')
-					span(v-for='(error, index) in field.errors', track-by='index') {{ error }}
+				.errors(v-if='fieldErrors(field).length > 0')
+					span(v-for='(error, index) in fieldErrors(field)', track-by='index') {{ error }}
 </template>
 
 <script>
@@ -126,7 +126,7 @@ div
 			// Get style classes of field
 			getFieldRowClasses(field) {
 				let baseClasses = {
-					error: field.errors && field.errors.length > 0, 
+					error: this.fieldErrors(field).length > 0, 
 					disabled: this.fieldDisabled(field), 
 					readonly: this.fieldReadonly(field), 
 					featured: this.fieldFeatured(field), 
@@ -208,7 +208,7 @@ div
 			// Child field executed validation
 			onFieldValidated(res, errors, field) {
 				this.errors = this.errors.filter(e => e.field != field.schema);
-				
+
 				// Remove old errors for this field
 				if (!res && errors && errors.length > 0) {
 					// Add errors with this field
@@ -263,8 +263,14 @@ div
 				return field.buttons && field.buttons.length > 0;
 			},
 			
-			errorsVisibility(field) {
-				return field.errors && field.errors.length > 0;
+			fieldErrors(field) {
+				let res = this.errors.filter(e => e.field == field);
+				if (res.length > 0)
+					console.log("res", res);
+				let res2 = res.map(item => item.error);
+				if (res2.length > 0)
+					console.log("res2", res2);
+				return res2;
 			}
 		}
 	};

--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -207,7 +207,8 @@ div
 
 			// Child field executed validation
 			onFieldValidated(res, errors, field) {
-				this.errors = this.errors.filter(e => e.field == field.schema);
+				this.errors = this.errors.filter(e => e.field != field.schema);
+				
 				// Remove old errors for this field
 				if (!res && errors && errors.length > 0) {
 					// Add errors with this field

--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -265,12 +265,7 @@ div
 			
 			fieldErrors(field) {
 				let res = this.errors.filter(e => e.field == field);
-				if (res.length > 0)
-					console.log("res", res);
-				let res2 = res.map(item => item.error);
-				if (res2.length > 0)
-					console.log("res2", res2);
-				return res2;
+				return res.map(item => item.error);
 			}
 		}
 	};

--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -222,7 +222,9 @@ div
 					}
 				});
 
-				return this.errors.length == 0;
+				let isValid = this.errors.length == 0;
+				this.$emit('on-validated', isValid, this.errors);
+				return isValid;
 			},
 
 			// Clear validation errors

--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -207,9 +207,9 @@ div
 
 			// Child field executed validation
 			onFieldValidated(res, errors, field) {
+				// Remove old errors for this field
 				this.errors = this.errors.filter(e => e.field != field.schema);
 
-				// Remove old errors for this field
 				if (!res && errors && errors.length > 0) {
 					// Add errors with this field
 					errors.forEach((err) => {

--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -153,7 +153,7 @@ div
 			// Get disabled attr of field
 			fieldDisabled(field) {
 				if (isFunction(field.disabled))
-					return field.disabled(this.model);
+					return field.disabled.call(this, this.model, field, this);
 
 				if (isNil(field.disabled))
 					return false;
@@ -164,7 +164,7 @@ div
 			// Get required prop of field
 			fieldRequired(field) {
 				if (isFunction(field.required))
-					return field.required(this.model);
+					return field.required.call(this, this.model, field, this);
 
 				if (isNil(field.required))
 					return false;
@@ -175,7 +175,7 @@ div
 			// Get visible prop of field
 			fieldVisible(field) {
 				if (isFunction(field.visible))
-					return field.visible(this.model);
+					return field.visible.call(this, this.model, field, this);
 
 				if (isNil(field.visible))
 					return true;
@@ -186,7 +186,7 @@ div
 			// Get readonly prop of field
 			fieldReadonly(field) {
 				if (isFunction(field.readonly))
-					return field.readonly(this.model);
+					return field.readonly.call(this, this.model, field, this);
 
 				if (isNil(field.readonly))
 					return false;
@@ -197,7 +197,7 @@ div
 			// Get featured prop of field
 			fieldFeatured(field) {
 				if (isFunction(field.featured))
-					return field.featured(this.model);
+					return field.featured.call(this, this.model, field, this);
 
 				if (isNil(field.featured))
 					return false;

--- a/test/unit/specs/VueFormGenerator.spec.js
+++ b/test/unit/specs/VueFormGenerator.spec.js
@@ -281,6 +281,36 @@ describe("VueFormGenerator.vue", () => {
 
 	});
 
+	describe("check fieldDisabled function parameters", () => {
+		let schema = {
+			fields: [
+				{	
+					type: "input",		
+					inputType: "text",
+					label: "Name", 
+					model: "name", 
+					disabled: sinon.spy()
+				}
+			]
+		};
+
+		let model = {
+			name: "John Doe",
+			status: true
+		};
+
+		before( () => {
+			createFormGenerator(schema, model);
+		});
+
+		it("should be called with correct params", () => {
+			let spy = schema.fields[0].disabled;
+			expect(spy.called).to.be.true;
+			expect(spy.calledWith(model, schema.fields[0], vm.$children[0])).to.be.true;
+		});	
+
+	});
+
 	describe("check fieldDisabled with const", () => {
 		let schema = {
 			fields: [
@@ -629,7 +659,7 @@ describe("VueFormGenerator.vue", () => {
 
 	});
 
-	describe.only("check onValidated event", () => {
+	describe("check onValidated event", () => {
 		let schema = {
 			fields: [
 				{	

--- a/test/unit/specs/VueFormGenerator.spec.js
+++ b/test/unit/specs/VueFormGenerator.spec.js
@@ -629,6 +629,76 @@ describe("VueFormGenerator.vue", () => {
 
 	});
 
+	describe.only("check onValidated event", () => {
+		let schema = {
+			fields: [
+				{	
+					type: "input",	
+					inputType: "text", 	
+					label: "Name", 
+					model: "name", 
+					min: 3,
+					validator: VueFormGenerator.validators.string
+				}
+			]
+		};
+
+		let model = { name: "Bob" };
+		let form;
+		let onValidated = sinon.spy();
+
+		before( (done) => {
+			let elm = document.createElement("div");
+			vm = new Vue({
+				// eslint-disable-next-line quotes
+				template: `<vue-form-generator :schema="schema" :model="model" :options="options" :multiple="false" ref="form" @on-validated="onValidated"></vue-form-generator>`,
+				data: {
+					schema,
+					model,
+					options: {}
+				},
+				methods: {
+					onValidated
+				}
+			}).$mount(elm);
+
+			el = vm.$el;
+			vm.$nextTick( () => {
+				form = vm.$refs.form;
+				done();
+			});
+		});
+
+		it("should no errors after mounted()", (done) => {
+			vm.$nextTick( () => {
+				expect(form.errors).to.be.length(0);
+				done();
+			});
+		});
+
+		it("should be validation error if model value is not valid", () => {
+			vm.model.name = "A";
+			onValidated.reset();
+			form.validate();
+
+			expect(form.errors).to.be.length(1);
+			expect(onValidated.callCount).to.be.equal(1);
+			// console.log(onValidated.getCall(0).args[1][0].field);
+			// console.log(schema.fields[0]);
+			expect(onValidated.calledWith(false, [{ field: schema.fields[0], error: "The length of text is too small! Current: 1, Minimum: 3"}] )).to.be.true;
+		});		
+
+		it("should no validation error if model valie is valid", () => {
+			vm.model.name = "Alan";
+			onValidated.reset();
+			form.validate();
+
+			expect(form.errors).to.be.length(0);
+			expect(onValidated.callCount).to.be.equal(1);
+			expect(onValidated.calledWith(true, [] )).to.be.true;
+		});	
+	});
+
 	describe("check schema.onChanged when the model changed", () => {
 		let schema = {
 			fields: [

--- a/test/unit/specs/VueFormGenerator.spec.js
+++ b/test/unit/specs/VueFormGenerator.spec.js
@@ -109,7 +109,7 @@ describe("VueFormGenerator.vue", () => {
 		});		
 
 		it("should be error class", (done) => {
-			Vue.set(vm.schema.fields[0], "errors", [ "!!!" ]);
+			vm.$refs.form.errors.push({ field: vm.schema.fields[0], error: "Validation error!" });
 			vm.$nextTick(() => {
 				expect(group.classList.contains("error")).to.be.true;
 				done();
@@ -207,7 +207,8 @@ describe("VueFormGenerator.vue", () => {
 		});
 
 		it("should be .errors div if there are errors in fields", (done) => {
-			vm.schema.fields[0].errors.push("Some error!", "Another error!");
+			vm.$refs.form.errors.push({ field: vm.schema.fields[0], error: "Some error!" });
+			vm.$refs.form.errors.push({ field: vm.schema.fields[0], error: "Another error!" });
 			vm.$nextTick(() => {
 				let div = group.querySelector(".errors");
 				expect(div).to.be.exist;

--- a/test/unit/specs/VueFormGenerator.spec.js
+++ b/test/unit/specs/VueFormGenerator.spec.js
@@ -681,7 +681,7 @@ describe("VueFormGenerator.vue", () => {
 			let elm = document.createElement("div");
 			vm = new Vue({
 				// eslint-disable-next-line quotes
-				template: `<vue-form-generator :schema="schema" :model="model" :options="options" :multiple="false" ref="form" @on-validated="onValidated"></vue-form-generator>`,
+				template: `<vue-form-generator :schema="schema" :model="model" :options="options" :multiple="false" ref="form" @validated="onValidated"></vue-form-generator>`,
 				data: {
 					schema,
 					model,

--- a/test/unit/specs/fields/abstractField.spec.js
+++ b/test/unit/specs/fields/abstractField.spec.js
@@ -351,7 +351,7 @@ describe("abstractField.vue", function() {
 			expect(res[0]).to.be.equal("Validation error!");
 
 			expect(schema.onValidated.calledOnce).to.be.true;
-			expect(schema.onValidated.calledWith(model, field.schema.errors, schema)).to.be.true;
+			expect(schema.onValidated.calledWith(model, field.errors, schema)).to.be.true;
 		});
 
 	});		
@@ -370,19 +370,19 @@ describe("abstractField.vue", function() {
 		});
 
 		it("should be undefined", () => {
-			expect(schema.errors).to.be.undefined;
+			expect(field.errors).to.be.an.array;
 		});
 
 		it("should be an empty array", () => {
 			field.clearValidationErrors();
-			expect(schema.errors).to.be.defined;
-			expect(schema.errors).to.be.length(0);
+			expect(field.errors).to.be.defined;
+			expect(field.errors).to.be.length(0);
 		});
 
 		it("should contain one error string", () => {
 			field.validate();
-			expect(schema.errors).to.be.length(1);
-			expect(schema.errors[0]).to.be.equal("Validation error!");
+			expect(field.errors).to.be.length(1);
+			expect(field.errors[0]).to.be.equal("Validation error!");
 		});
 
 	});	

--- a/test/unit/specs/fields/abstractField.spec.js
+++ b/test/unit/specs/fields/abstractField.spec.js
@@ -2,6 +2,7 @@
 import { expect } from "chai";
 
 import Vue from "vue";
+import VueFormGenerator from "src/index";
 import AbstractField from "src/fields/abstractField";
 AbstractField.template = "<div></div>";
 Vue.component("AbstractField", AbstractField);
@@ -355,6 +356,68 @@ describe("abstractField.vue", function() {
 		});
 
 	});		
+
+	describe("check schema onValidated event", () => {
+		let schema = {
+			type: "text",
+			label: "Name",
+			model: "name",
+			min: 3,
+			validator: VueFormGenerator.validators.string
+		};
+		let model = { name: "John Doe" };
+		let onValidated = sinon.spy();
+
+		beforeEach( () => {
+			let elm = document.createElement("div");		
+
+			vm = new Vue({
+				// eslint-disable-next-line quotes
+				template: `<abstract-field :schema="schema" :model="model" ref="field" @validated="onValidated"></abstract-field>`,
+				data: {
+					schema,
+					model
+				},
+				methods: {
+					onValidated
+				}
+			}).$mount(elm);
+			el = vm.$el;
+
+			field = vm.$refs.field;		
+		});
+
+		it("should return empty array", () => {
+			onValidated.reset();
+			let res = field.validate();
+			expect(res).to.be.an.array;
+			expect(res.length).to.be.equal(0);
+
+			expect(onValidated.callCount).to.be.equal(1);
+			expect(onValidated.calledWith(true, [])).to.be.true;
+		});
+
+		it("should not call 'onValidated'", () => {
+			onValidated.reset();
+			let res = field.validate(true);
+			expect(res).to.be.an.array;
+			expect(res.length).to.be.equal(0);
+
+			expect(onValidated.callCount).to.be.equal(0);
+		});
+
+		it("should return empty array", () => {
+			model.name = "Al";
+			onValidated.reset();
+			let res = field.validate();
+			expect(res).to.be.an.array;
+			expect(res.length).to.be.equal(1);
+			expect(res[0]).to.be.equal("The length of text is too small! Current: 2, Minimum: 3");
+
+			expect(onValidated.callCount).to.be.equal(1);
+			expect(onValidated.calledWith(false, field.errors, field)).to.be.true;
+		});
+	});
 
 	describe("check clearValidationErrors", () => {
 		let schema = {

--- a/test/unit/webpack.test.config.js
+++ b/test/unit/webpack.test.config.js
@@ -68,10 +68,11 @@ module.exports = {
 		autoprefixer: {
 			browsers: ["last 2 versions"]
 		},
-		// Comment this, if you would like to debug under `npm run ci`
-		/*loaders: {
+
+		// Comment out this, if you would like to debug under `npm run ci`
+		loaders: {
 			js: "isparta"
-		}*/
+		}
 	}
  
 };

--- a/test/unit/webpack.test.config.js
+++ b/test/unit/webpack.test.config.js
@@ -68,9 +68,10 @@ module.exports = {
 		autoprefixer: {
 			browsers: ["last 2 versions"]
 		},
-		loaders: {
+		// Comment this, if you would like to debug under `npm run ci`
+		/*loaders: {
 			js: "isparta"
-		}
+		}*/
 	}
  
 };


### PR DESCRIPTION
Concerned issues: #128 #109 

1. VFG component emits a `validated` event, if validation executed. Event parameters: `isValid: boolean, errors: Array`

Example:
```js
<vue-form-generator @validated="onValidated" />

...

methods:{
  onValidated(isValid, errors) {
   console.log("Validation result: ", isValid, ", Errors:", errors);
  }
}

```

2. Fields validation `schema.errors` issue is fixed. Now `errors` in the local data. The communication with parent is event-based (similar `@validated` solution)

3. Fix `this` in schema functions. Now `this` is always the instance of field. Parameters: `model, fieldSchema, field`