### PR TITLE
Fix a problem with value define but not an Array

### DIFF
--- a/src/fields/core/fieldChecklist.vue
+++ b/src/fields/core/fieldChecklist.vue
@@ -68,12 +68,13 @@
 			},
 
 			onChanged(event, item) {
-				if (isNil(this.value))
+				if (isNil(this.value) || !Array.isArray(this.value)){
 					this.$set(this, "value", []);
+				}
 
-				if (event.target.checked)
+				if (event.target.checked) {
 					this.value.push(this.getItemID(item));
-				else {
+				} else {
 					this.value.splice(this.value.indexOf(this.getItemID(item)), 1);
 				}
 			},


### PR DESCRIPTION
If the model is initialized with an empty string, when checked/clicked, the push was failing because value is not an array.
```js
model: {
    checklist:''
},
schema: {
    fields: [
            {
            type: "checklist",
            label: "CHECKLIST",
            model: "checklist",
            listBox: true,
            values: [{
                name: "HTML5",
                value: "HTML5-123"
            }, {
                name: "Javascript",
                value: "Javascript-123"
            }],
            }
	]
}
```

````
TypeError: this.value.push is not a function
````