### PR TITLE
Add support for schema.legend & field.id prefixes

### DIFF
--- a/dev/multipleforms/app.vue
+++ b/dev/multipleforms/app.vue
@@ -1,0 +1,59 @@
+<template lang="html">
+	<form>
+		<vue-form-generator :schema="section1" :model="model" :options="formOptions"></vue-form-generator>
+		<vue-form-generator :schema="section2" :model="model" :options="formOptions"></vue-form-generator>
+	</form>
+</template>
+
+<script>
+import Vue from "vue";
+
+export default {
+	data () {
+		return {
+			model: {
+				name: 'Brian Blessed',
+				email: "brian@hawkman.mongo",
+				pref_1: 'blah'
+			},
+
+			section1: {
+				legend: "Contact Details",
+				fields: [
+					{
+						type: "input",
+						inputType: "text",
+						label: "Name",
+						model: "name"
+					},
+					{
+						type: "input",
+						inputType: "email",
+						label: "Email",
+						model: "email"
+					}
+				]
+			},
+
+			section2: {
+				fields: [
+					{
+						type: "input",
+						inputType: "text",
+						label: "Pref 1",
+						model: "pref_1"
+					}
+				]
+			},
+
+			formOptions: {
+				fieldIdPrefix: 'frm1_'
+			}
+		}
+	},
+
+	created() {
+		window.app = this;
+	}
+}
+</script>

--- a/dev/multipleforms/index.html
+++ b/dev/multipleforms/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>vue-form-generator multiple forms demo</title>
+  </head>
+  <body>
+    <div class="container-fluid"></div>
+    <div id="app"></div>
+  	<script src="/mforms.js"></script>
+  </body>
+</html>

--- a/dev/multipleforms/main.js
+++ b/dev/multipleforms/main.js
@@ -1,0 +1,9 @@
+import Vue from "vue";
+import VueFormGenerator from "../../src";
+Vue.use(VueFormGenerator);
+
+import App from './app.vue';
+
+new Vue({
+    ...App
+}).$mount('#app');

--- a/src/fields/abstractField.js
+++ b/src/fields/abstractField.js
@@ -167,10 +167,10 @@ export default {
 			// then slugify it.
 			if (typeof schema.id !== "undefined") {
 				// If an ID's been explicitly set, use it unchanged
-				return schema.id;
+				return schema.idPrefix + schema.id;
 			} else {
 				// Return the slugified version of either:
-				return (schema.inputName || schema.label || schema.model)
+				return schema.idPrefix + (schema.inputName || schema.label || schema.model)
 				// NB: This is a very simple, conservative, slugify function,
 				// avoiding extra dependencies.
 				.toString()

--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -1,6 +1,7 @@
 <template lang="pug">
 div
 	fieldset.vue-form-generator(v-if='schema != null', :is='tag')
+		legend(v-if='schema.legend') {{ schema.legend }}
 		template(v-for='field in fields')
 			.form-group(v-if='fieldVisible(field)', :class='getFieldRowClasses(field)')
 				label(v-if="fieldTypeHasLabel(field)", :for="getFieldID(field)")
@@ -119,6 +120,13 @@ div
 							this.clearValidationErrors();
 					});
 				}
+			}
+		},
+
+		beforeMount() {
+			// Add idPrefix to fields if fieldIdPrefix is set
+			for (let field of this.schema.fields) {
+				field.idPrefix = this.options.fieldIdPrefix || "";
 			}
 		},
 

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -17,23 +17,24 @@ var loaders = [
 		test: /\.json$/,
 		loader: 'json'
 	},
-	{ 
-		test: /\.(woff2?|svg)$/, 
-		loader: "url" 
-		//loader: "url?limit=10000" 
+	{
+		test: /\.(woff2?|svg)$/,
+		loader: "url"
+		//loader: "url?limit=10000"
 	},
-	{ 
-		test: /\.(ttf|eot)$/, 
-		loader: "url" 
+	{
+		test: /\.(ttf|eot)$/,
+		loader: "url"
 	}
 ];
 
 module.exports = {
 	devtool: "source-map",
-	
+
 	entry: {
 		full: path.resolve("dev", "full", "main.js"),
 		mselect: path.resolve("dev", "multiselect", "main.js"),
+		mforms: path.resolve("dev", "multipleforms", "main.js"),
 		checklist: path.resolve("dev", "checklist", "main.js")
 	},
 


### PR DESCRIPTION
1. Add support for an optional legend for each schema/fieldset. Expects the schema to look something  like this:

```
schema: {
  legend: "Contact Details",
  fields: [
    {
      type: "input",
      inputType: "text",
      label: "Name",
      model: "name"
    },
...
```

2. Add support for field id prefixes, at the form level. So you can add a `fieldIdPrefix: 'prefix_here_'` to your `formOptions` and this will be prepended to _all_ field id's. So if you have this:

```js
schema: {
  legend: "Contact Details",
  fields: [
    {
      type: "input",
      inputType: "text",
      label: "Name",
      model: "name"
    },
    {
      type: "input",
      inputType: "email",
      label: "Email",
      model: "email",
      id: "user_email"
    }
  ]
},


formOptions: {
  fieldIdPrefix: 'frm1_'
}
```

you'll get this:

```html
<fieldset class="vue-form-generator">
  <legend>Contact Details</legend>
  <div class="form-group field-input">
    <label for="frm1_name">Name</label>
    <div class="field-wrap">
      <div class="wrapper">
        <input id="frm1_name" type="text" class="form-control">
      </div>
    </div>
  </div>
  <div class="form-group field-input">
    <label for="frm1_email">Email</label>
    <div class="field-wrap">
      <div class="wrapper">
        <input id="frm1_email" type="email" class="form-control">
      </div>
    </div>
  </div>
</fieldset>
```

So the `idPrefix` is (intentionally) applied to both auto-generated and manually set field ids.

I added a `dev/multipleforms` thing to demo this - which should probably be called `multiplefieldsets` or `legends` or something.