### PR TITLE
Add access to click event on buttons

### DIFF
--- a/src/formGenerator.vue
+++ b/src/formGenerator.vue
@@ -11,7 +11,7 @@ div.vue-form-generator(v-if='schema != null')
 				.field-wrap
 					component(:is='getFieldType(field)', :disabled='fieldDisabled(field)', :model='model', :schema='field', :formOptions='options', @model-updated='modelUpdated', @validated="onFieldValidated")
 					.buttons(v-if='buttonVisibility(field)')
-						button(v-for='btn in field.buttons', @click='buttonClickHandler(btn, field)', :class='btn.classes') {{ btn.label }}
+						button(v-for='btn in field.buttons', @click='buttonClickHandler(btn, field, $event)', :class='btn.classes') {{ btn.label }}
 				.hint(v-if='field.hint') {{ field.hint }}
 				.errors.help-block(v-if='fieldErrors(field).length > 0')
 					span(v-for='(error, index) in fieldErrors(field)', track-by='index') {{ error }}
@@ -29,7 +29,7 @@ div.vue-form-generator(v-if='schema != null')
 					.field-wrap
 						component(:is='getFieldType(field)', :disabled='fieldDisabled(field)', :model='model', :schema='field', :formOptions='options',@model-updated='modelUpdated', @validated="onFieldValidated")
 						.buttons(v-if='buttonVisibility(field)')
-							button(v-for='btn in field.buttons', @click='buttonClickHandler(btn, field)', :class='btn.classes') {{ btn.label }}
+							button(v-for='btn in field.buttons', @click='buttonClickHandler(btn, field, $event)', :class='btn.classes') {{ btn.label }}
 					.hint(v-if='field.hint') {{ field.hint }}
 					.errors.help-block(v-if='fieldErrors(field).length > 0')
 						span(v-for='(error, index) in fieldErrors(field)', track-by='index') {{ error }}
@@ -276,8 +276,8 @@ div.vue-form-generator(v-if='schema != null')
 				return field.featured;
 			},
 
-			buttonClickHandler(btn, field) {
-				return btn.onclick.call(this, this.model, field, this);
+			buttonClickHandler(btn, field, event) {
+				return btn.onclick.call(this, this.model, field, event, this);
 			},
 
 			// Child field executed validation


### PR DESCRIPTION
Uses built-in Vue $event special variable to pass DOM click event to button onclick functions as a third parameter.

Allows for use of stopPropagation, etc.

Shouldn't cause any breaking changes.