### PR TITLE
Add an option to hide the none selected text

### DIFF
--- a/src/fields/core/fieldSelect.vue
+++ b/src/fields/core/fieldSelect.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 	select.form-control(v-model="value", :disabled="disabled", :name="schema.inputName", :id="getFieldID(schema)")
-		option(:disabled="schema.required", :value="null", :selected="value == undefined") {{ selectOptions.noneSelectedText || "&lt;Nothing selected&gt;" }}
+		option(v-if="!selectOptions.hideNoneSelectedText", :disabled="schema.required", :value="null", :selected="value == undefined") {{ selectOptions.noneSelectedText || "&lt;Nothing selected&gt;" }}
 		option(v-for="item in items", :value="getItemID(item)") {{ getItemName(item) }}
 </template>
 

--- a/test/unit/specs/fields/fieldSelect.spec.js
+++ b/test/unit/specs/fields/fieldSelect.spec.js
@@ -121,6 +121,22 @@ describe("fieldSelect.vue", function() {
 			});
 		});
 
+		it("should hide the customized <non selected> text", (done) => {
+			Vue.set(vm.schema, "selectOptions", {
+				noneSelectedText: "Empty list",
+				hideNoneSelectedText: true
+			});
+			vm.$nextTick( () => {
+				let options = input.querySelectorAll("option");
+				expect(options[0].disabled).to.be.false;
+				expect(options[0].textContent).to.not.be.equal("Empty list");
+
+				schema.selectOptions = null;
+
+				done();
+			});
+		});
+
 	});
 
 	describe("check static values with { id, name } objects", () => {


### PR DESCRIPTION
As a solution to #210, I added an option `hideNoneSelectedText` in `selectOptions`
```js
{			
	type: "select",
	label: "Role",
	model: "role",
	required: true,
	selectOptions: {
		hideNoneSelectedText: true
	},
	values: [{
		id: "admin",
		name: "Administrator"
	}, {
		id: "moderator",
		name: "Moderator"
	}, {
		id: "user",
		name: "Registered User"
	}, {
		id: "visitor",
		name: "Visitor"
	}],
	styleClasses: "half-width",
	validator: validators.required
}
```